### PR TITLE
Adding the new meta data into the event REST data.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: events, calendar
 Requires at least: 4.5
 Tested up to: 5.3.2
 Requires PHP: 5.6
-Stable tag: 1.0.0
+Stable tag: 1.1.0
 License: GPL version 3 or any later version
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -35,6 +35,10 @@ We're always interested in your feedback and our [Help Desk](https://support.the
 
 == Changelog ==
 
+= [1.0.1] 2020-03-26 =
+
+* Provide `event_status`, `event_status_reason`, `is_online`, and `online_url` in REST data for events.
+
 = [1.0.0] 2020-03-24 =
 
-* Initial release
+* Initial release.

--- a/src/Tribe/Event_Meta.php
+++ b/src/Tribe/Event_Meta.php
@@ -53,4 +53,117 @@ class Event_Meta {
 	 * @var string
 	 */
 	public static $key_online_url = '_tribe_events_control_online_url';
+
+	/**
+	 * Retrieves an event's status.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param WP_Post $event Event post object.
+	 *
+	 * @return null|string The event's status.
+	 */
+	public function get_status( $event ) {
+		return get_post_meta( $event->ID, static::$key_status, true );
+	}
+
+	/**
+	 * Retrieves an event's cancellation reason.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param WP_Post $event Event ID.
+	 *
+	 * @return null|string The event's cancellation reason.
+	 */
+	public function get_canceled_reason( $event ) {
+		return get_post_meta( $event->ID, static::$key_status_canceled_reason, true );
+	}
+
+	/**
+	 * Retrieves an event's postponed reason.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param WP_Post $event Event post object.
+	 *
+	 * @return null|string The event's postponed reason.
+	 */
+	public function get_postponed_reason( $event ) {
+		return get_post_meta( $event->ID, static::$key_status_postponed_reason, true );
+	}
+
+	/**
+	 * Retrieves an event's online URL.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param WP_Post $event Event post object.
+	 *
+	 * @return null|string The event's online URL.
+	 */
+	public function get_online_url( $event ) {
+		return get_post_meta( $event->ID, static::$key_online_url, true );
+	}
+
+	/**
+	 * Retrieves whether the event is marked as online or not.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param WP_Post $event Event post object.
+	 *
+	 * @return bool Whether the event is online or not.
+	 */
+	public function is_online( $event ) {
+		return tribe_is_truthy( get_post_meta( $event->ID, static::$key_online, true ) );
+	}
+
+	/**
+	 * Retrieves event control meta.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param WP_Post $event Event post object.
+	 *
+	 * @return mixed|void
+	 */
+	public function get_meta( $event ) {
+		$data       = [];
+		$status     = $this->get_status( $event );
+		$reason     = null;
+		$is_online  = $this->is_online( $event );
+		$online_url = null;
+
+		if ( ! empty( $status ) || ! empty( $is_online ) ) {
+			if ( $is_online ) {
+				$online_url = $this->get_online_url( $event );
+			}
+
+			if ( 'canceled' === $status ) {
+				$reason = $this->get_canceled_reason( $event );
+			}
+
+			if ( 'postponed' === $status ) {
+				$reason = $this->get_postponed_reason( $event );
+			}
+
+			$data = [
+				'event_status'        => $status,
+				'event_status_reason' => $reason,
+				'is_online'           => (bool) $is_online,
+				'online_url'          => $online_url,
+			];
+		}
+
+		/**
+		 * Filters the events control meta returned by this method.
+		 *
+		 * @since 1.1.0
+		 *
+		 * @param array $data Meta data.
+		 * @param WP_Post $event Event post object.
+		 */
+		return apply_filters( 'tribe_ext_events_control_meta_data', $data, $event );
+	}
 }

--- a/src/Tribe/Hooks.php
+++ b/src/Tribe/Hooks.php
@@ -71,6 +71,7 @@ class Hooks extends \tad_DI52_ServiceProvider {
 		add_filter( 'tribe_the_notices', [ $this, 'filter_include_single_control_markers' ], 15, 2 );
 		add_filter( 'tribe_json_ld_event_object', [ $this, 'filter_json_ld_modifiers' ], 15, 3 );
 		add_filter( 'post_class', [ $this, 'filter_add_post_class' ], 15, 3 );
+		add_filter( 'tribe_rest_event_data', [ $this, 'filter_rest_event_data'], 10, 2 );
 	}
 
 	/**
@@ -149,6 +150,25 @@ class Hooks extends \tad_DI52_ServiceProvider {
 		$data = $this->container->make( JSON_LD::class )->modify_canceled_event( $data, $args, $post );
 		$data = $this->container->make( JSON_LD::class )->modify_postponed_event( $data, $args, $post );
 		return $this->container->make( JSON_LD::class )->modify_online_event( $data, $args, $post );
+	}
+
+	/**
+	 * Filters event REST data to include new fields.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param array $data The event data array.
+	 * @param WP_Post $event The post object.
+	 *
+	 * @return array The event data array after modification.
+	 */
+	public function filter_rest_event_data( $data, $event ) {
+		$meta = tribe( Event_Meta::class )->get_meta( $event );
+		if ( empty( $meta ) ) {
+			return $data;
+		}
+
+		return array_merge( $data, $meta );
 	}
 
 	/**

--- a/src/Tribe/JSON_LD.php
+++ b/src/Tribe/JSON_LD.php
@@ -36,7 +36,7 @@ class JSON_LD {
 		if ( empty( $data->startDate ) || empty( $data->endDate ) ) {
 			return $data;
 		}
-		$status = get_post_meta( $post->ID, Event_Meta::$key_status, true );
+		$status = tribe( Event_Meta::class )->get_status( $post->ID );
 
 		// Bail on modifications for non canceled events.
 		if ( 'canceled' !== $status ) {
@@ -63,7 +63,7 @@ class JSON_LD {
 		if ( empty( $data->startDate ) || empty( $data->endDate ) ) {
 			return $data;
 		}
-		$status = get_post_meta( $post->ID, Event_Meta::$key_status, true );
+		$status = tribe( Event_Meta::class )->get_status( $post->ID );
 
 		// Bail on modifications for non canceled events.
 		if ( 'postponed' !== $status ) {
@@ -91,8 +91,8 @@ class JSON_LD {
 		if ( empty( $data->startDate ) || empty( $data->endDate ) ) {
 			return $data;
 		}
-		$online = tribe_is_truthy( get_post_meta( $post->ID, Event_Meta::$key_online, true ) );
-		$online_url = get_post_meta( $post->ID, Event_Meta::$key_online_url, true );
+		$online     = tribe( Event_Meta::class )->is_online( $post->ID );
+		$online_url = tribe( Event_Meta::class )->get_online_url( $post->ID );
 
 		// Bail on modifications for non canceled events.
 		if ( ! $online ) {

--- a/src/Tribe/Service_Provider.php
+++ b/src/Tribe/Service_Provider.php
@@ -25,6 +25,7 @@ class Service_Provider extends \tad_DI52_ServiceProvider {
 			return;
 		}
 
+		$this->container->singleton( Event_Meta::class, Event_Meta::class );
 		$this->container->singleton( Metabox::class, Metabox::class, [ 'set_template' ] );
 		$this->container->singleton( JSON_LD::class, JSON_LD::class );
 		$this->container->singleton( Template_Modifications::class, Template_Modifications::class, [ 'set_template' ] );

--- a/tribe-ext-events-control.php
+++ b/tribe-ext-events-control.php
@@ -4,7 +4,7 @@
  * Plugin URI:        https://theeventscalendar.com/extensions/events-control/
  * GitHub Plugin URI: https://github.com/mt-support/tribe-ext-events-control
  * Description:
- * Version:           1.0.0
+ * Version:           1.1.0
  * Extension Class:   Tribe\Extensions\EventsControl\Main
  * Author:            Modern Tribe, Inc.
  * Author URI:        http://m.tri.be/1971
@@ -56,7 +56,7 @@ if (
 		 *
 		 * @var string
 		 */
-		const VERSION = '1.0.0';
+		const VERSION = '1.1.0';
 
 		/**
 		 * Stores the base slug for the extension.


### PR DESCRIPTION
This way, other services (like Promoter) can leverage the meta data as needed.

![Screen Shot 2020-03-26 at 11 49 40 AM](https://user-images.githubusercontent.com/430385/77667041-19dde880-6f58-11ea-83aa-cfa3ff82987d.png)
