### PR TITLE
Add status label to Widget

### DIFF
--- a/src/Tribe/Hooks.php
+++ b/src/Tribe/Hooks.php
@@ -112,6 +112,9 @@ class Hooks extends \tad_DI52_ServiceProvider {
 		add_filter( 'tribe_template_html:events-pro/v2/week/grid-body/events-day/event/tooltip/title', [ $this, 'filter_insert_status_label' ], 15, 4 );
 		add_filter( 'tribe_template_html:events-pro/v2/week/grid-body/multiday-events-day/multiday-event', [ $this, 'filter_insert_status_label' ], 15, 4 );
 		add_filter( 'tribe_template_html:events-pro/v2/week/mobile-events/day/event/title', [ $this, 'filter_insert_status_label' ], 15, 4 );
+		
+		//Widget
+		add_filter( 'tribe_template_html:events/v2/widgets/widget-events-list/event/title', [ $this, 'filter_insert_status_label' ], 15, 4 );
 	}
 
 	/**

--- a/src/Tribe/Template_Modifications.php
+++ b/src/Tribe/Template_Modifications.php
@@ -56,6 +56,8 @@ class Template_Modifications {
 		'week/grid-body/events-day/event/tooltip/title:status-label'                        => '/(<h3 class="tribe-events-pro-week-grid__event-tooltip-title tribe-common-h7">)/',
 		'week/grid-body/multiday-events-day/multiday-event:status-label'                    => '/(<h3 class="tribe-events-pro-week-grid__multiday-event-bar-title tribe-common-h8 tribe-common-h--alt">)/',
 		'week/mobile-events/day/event/title:status-label'                                   => '/(<h3 class="tribe-events-pro-week-mobile-events__event-title tribe-common-h6 tribe-common-h5--min-medium">)/',
+		// Widget
+		'widgets/widget-events-list/event/title:status-label'                               => '/(<h3 class="tribe-events-widget-events-list__event-title tribe-common-h7">)/',
 	];
 
 	/**


### PR DESCRIPTION
The canceled/postponed label wasn't shown in the widget. 

This change enables the widget to show the canceled/postponed label.
![image](https://user-images.githubusercontent.com/46853637/115114952-2c2b2a00-9f92-11eb-9470-cdf5b6f6b256.png)
